### PR TITLE
fix: handle null API response to prevent permanent unavailability

### DIFF
--- a/custom_components/meteoam/coordinator.py
+++ b/custom_components/meteoam/coordinator.py
@@ -142,6 +142,8 @@ class MeteoAMWeatherData:
             raise CannotConnectError(f"API returned status {resp.status}")
 
         data = await resp.json()
+        if not data:
+            raise CannotConnectError("API returned empty response")
 
         # Parse daily forecast from stats
         self.daily_forecast = []


### PR DESCRIPTION
## Problem

The MeteoAM API occasionally returns a null JSON body with HTTP 200. Without a guard, this causes an unhandled `AttributeError` that the coordinator treats as an unexpected error, leaving the entity stuck as "Non disponibile" until Home Assistant is restarted.

## Fix

Added a `not data` check after `resp.json()` that raises `CannotConnectError`. This ensures the coordinator properly wraps it as `UpdateFailed`, which triggers normal retry behavior on the next update interval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling to provide clearer feedback when connectivity issues occur. The system now properly detects when the API returns empty or invalid responses and reports this as a connection error instead of failing silently. This prevents confusing and unclear errors that could occur during subsequent data parsing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->