### PR TITLE
Add retry behavior for transient API errors in data fetching

### DIFF
--- a/custom_components/meteoam/coordinator.py
+++ b/custom_components/meteoam/coordinator.py
@@ -164,24 +164,23 @@ class MeteoAMWeatherData:
 
         timeout = aiohttp.ClientTimeout(total=60)
         try:
-            resp = await self._session.get(url, timeout=timeout)
+            async with self._session.get(url, timeout=timeout) as resp:
+                if resp.status >= 500:
+                    raise TransientAPIError(f"API returned status {resp.status}")
+                if resp.status != 200:
+                    raise CannotConnectError(f"API returned status {resp.status}")
+
+                try:
+                    data = await resp.json()
+                except (aiohttp.ContentTypeError, ValueError) as err:
+                    raise CannotConnectError(
+                        f"Error parsing MeteoAM API response: {err}"
+                    ) from err
+
+                if not data:
+                    raise CannotConnectError("API returned empty response")
         except (aiohttp.ClientError, TimeoutError) as err:
             raise TransientAPIError(f"Error connecting to MeteoAM API: {err}") from err
-
-        if resp.status >= 500:
-            raise TransientAPIError(f"API returned status {resp.status}")
-        if resp.status != 200:
-            raise CannotConnectError(f"API returned status {resp.status}")
-
-        try:
-            data = await resp.json()
-        except (aiohttp.ContentTypeError, ValueError) as err:
-            raise CannotConnectError(
-                f"Error parsing MeteoAM API response: {err}"
-            ) from err
-
-        if not data:
-            raise CannotConnectError("API returned empty response")
 
         try:
             self._parse_data(data)

--- a/custom_components/meteoam/coordinator.py
+++ b/custom_components/meteoam/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable, Mapping
 from datetime import timedelta
@@ -23,6 +24,9 @@ from homeassistant.util import dt as dt_util
 
 from .const import CONF_TRACK_HOME, DOMAIN
 
+_MAX_ATTEMPTS = 3
+_RETRY_DELAY_S = 2
+
 # Dedicated Home Assistant endpoint - do not change!
 URL = "https://api.meteoam.it/deda-meteograms/api/GetMeteogram/preset1/{lat},{lon}"
 
@@ -33,6 +37,10 @@ type MeteoAMConfigEntry = ConfigEntry[MeteoAMDataUpdateCoordinator]
 
 class CannotConnectError(HomeAssistantError):
     """Unable to connect to the web site."""
+
+
+class TransientAPIError(CannotConnectError):
+    """Transient API error (network/5xx), safe to retry."""
 
 
 class MeteoAMDataUpdateCoordinator(DataUpdateCoordinator["MeteoAMWeatherData"]):
@@ -57,15 +65,33 @@ class MeteoAMDataUpdateCoordinator(DataUpdateCoordinator["MeteoAMWeatherData"]):
         )
 
     async def _async_update_data(self) -> MeteoAMWeatherData:
-        """Fetch data from MeteoAM."""
-        try:
-            return await self.weather.fetch_data()
-        except CannotConnectError as err:
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="update_failed",
-                translation_placeholders={"error": str(err)},
-            ) from err
+        """Fetch data from MeteoAM with retry on transient errors."""
+        for attempt in range(_MAX_ATTEMPTS):
+            try:
+                return await self.weather.fetch_data()
+            except TransientAPIError as err:
+                if attempt < _MAX_ATTEMPTS - 1:
+                    _LOGGER.warning(
+                        "MeteoAM API transient error (attempt %d/%d), "
+                        "retrying in %ds: %s",
+                        attempt + 1,
+                        _MAX_ATTEMPTS,
+                        _RETRY_DELAY_S,
+                        err,
+                    )
+                    await asyncio.sleep(_RETRY_DELAY_S)
+                else:
+                    raise UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="update_failed",
+                        translation_placeholders={"error": str(err)},
+                    ) from err
+            except CannotConnectError as err:
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="update_failed",
+                    translation_placeholders={"error": str(err)},
+                ) from err
 
     def track_home(self) -> None:
         """Start tracking changes to HA home setting."""
@@ -140,8 +166,10 @@ class MeteoAMWeatherData:
         try:
             resp = await self._session.get(url, timeout=timeout)
         except (aiohttp.ClientError, TimeoutError) as err:
-            raise CannotConnectError(f"Error connecting to MeteoAM API: {err}") from err
+            raise TransientAPIError(f"Error connecting to MeteoAM API: {err}") from err
 
+        if resp.status >= 500:
+            raise TransientAPIError(f"API returned status {resp.status}")
         if resp.status != 200:
             raise CannotConnectError(f"API returned status {resp.status}")
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -11,7 +11,9 @@ from homeassistant.util import dt as dt_util
 
 from custom_components.meteoam.coordinator import (
     CannotConnectError,
+    MeteoAMDataUpdateCoordinator,
     MeteoAMWeatherData,
+    TransientAPIError,
 )
 
 # --- Helpers for building fake API responses ---
@@ -364,3 +366,110 @@ class TestDailyForecastDatetime:
             assert isinstance(entry["localDateTime"], str), (
                 f"Expected str, got {type(entry['localDateTime'])}"
             )
+
+
+class TestTransientAPIError:
+    """Tests for transient vs non-retryable error classification in fetch_data."""
+
+    async def test_5xx_raises_transient_error(self, hass_mock):
+        """HTTP 5xx should raise TransientAPIError, a subclass of CannotConnectError."""
+        wd = _make_weather_data(hass_mock)
+        wd._session.get = AsyncMock(return_value=_mock_response(status=503))
+
+        with pytest.raises(TransientAPIError, match="API returned status 503"):
+            await wd.fetch_data()
+
+    async def test_network_error_raises_transient_error(self, hass_mock):
+        """aiohttp.ClientError should raise TransientAPIError."""
+        wd = _make_weather_data(hass_mock)
+        wd._session.get = AsyncMock(
+            side_effect=aiohttp.ClientConnectionError("connection refused")
+        )
+
+        with pytest.raises(TransientAPIError, match="Error connecting"):
+            await wd.fetch_data()
+
+    async def test_4xx_raises_cannot_connect_not_transient(self, hass_mock):
+        """HTTP 4xx should raise CannotConnectError but NOT TransientAPIError."""
+        wd = _make_weather_data(hass_mock)
+        wd._session.get = AsyncMock(return_value=_mock_response(status=404))
+
+        with pytest.raises(CannotConnectError):
+            await wd.fetch_data()
+
+        wd._session.get = AsyncMock(return_value=_mock_response(status=404))
+        with pytest.raises(Exception) as exc_info:
+            await wd.fetch_data()
+        assert not isinstance(exc_info.value, TransientAPIError)
+
+
+def _make_coordinator(hass_mock: MagicMock) -> MeteoAMDataUpdateCoordinator:
+    """Create a MeteoAMDataUpdateCoordinator with a mocked config entry."""
+    config_entry = MagicMock()
+    config_entry.data = {"latitude": "41.9", "longitude": "12.5"}
+    coordinator = MeteoAMDataUpdateCoordinator.__new__(MeteoAMDataUpdateCoordinator)
+    coordinator.hass = hass_mock
+    coordinator.logger = MagicMock()
+    coordinator.weather = MagicMock()
+    return coordinator
+
+
+class TestCoordinatorRetry:
+    """Tests for retry logic in _async_update_data."""
+
+    async def test_succeeds_after_transient_failures(self, hass_mock):
+        """Should succeed on 3rd attempt after 2 transient failures."""
+        coordinator = _make_coordinator(hass_mock)
+        weather_data = MagicMock()
+        coordinator.weather.fetch_data = AsyncMock(
+            side_effect=[
+                TransientAPIError("502"),
+                TransientAPIError("502"),
+                weather_data,
+            ]
+        )
+
+        with patch("custom_components.meteoam.coordinator.asyncio.sleep") as mock_sleep:
+            mock_sleep.return_value = None
+            result = await coordinator._async_update_data()
+
+        assert result is weather_data
+        assert mock_sleep.call_count == 2
+
+    async def test_raises_update_failed_after_max_retries(self, hass_mock):
+        """Should raise UpdateFailed after all 3 attempts fail with transient errors."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        coordinator = _make_coordinator(hass_mock)
+        coordinator.weather.fetch_data = AsyncMock(
+            side_effect=[
+                TransientAPIError("502"),
+                TransientAPIError("502"),
+                TransientAPIError("502"),
+            ]
+        )
+
+        with (
+            patch("custom_components.meteoam.coordinator.asyncio.sleep"),
+            pytest.raises(UpdateFailed),
+        ):
+            await coordinator._async_update_data()
+
+    async def test_no_retry_on_non_retryable_error(self, hass_mock):
+        """Should raise UpdateFailed immediately on non-retryable CannotConnectError."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        coordinator = _make_coordinator(hass_mock)
+        coordinator.weather.fetch_data = AsyncMock(
+            side_effect=CannotConnectError(
+                "Error parsing MeteoAM API response: bad json"
+            )
+        )
+
+        with (
+            patch("custom_components.meteoam.coordinator.asyncio.sleep") as mock_sleep,
+            pytest.raises(UpdateFailed),
+        ):
+            await coordinator._async_update_data()
+
+        mock_sleep.assert_not_called()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import aiohttp
 import pytest
 from homeassistant.util import dt as dt_util
 
 from custom_components.meteoam.coordinator import (
+    _MAX_ATTEMPTS,
+    _RETRY_DELAY_S,
     CannotConnectError,
     MeteoAMDataUpdateCoordinator,
     MeteoAMWeatherData,
@@ -394,11 +396,7 @@ class TestTransientAPIError:
         wd = _make_weather_data(hass_mock)
         wd._session.get = AsyncMock(return_value=_mock_response(status=404))
 
-        with pytest.raises(CannotConnectError):
-            await wd.fetch_data()
-
-        wd._session.get = AsyncMock(return_value=_mock_response(status=404))
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(CannotConnectError) as exc_info:
             await wd.fetch_data()
         assert not isinstance(exc_info.value, TransientAPIError)
 
@@ -434,7 +432,9 @@ class TestCoordinatorRetry:
             result = await coordinator._async_update_data()
 
         assert result is weather_data
-        assert mock_sleep.call_count == 2
+        assert coordinator.weather.fetch_data.call_count == _MAX_ATTEMPTS
+        assert mock_sleep.call_count == _MAX_ATTEMPTS - 1
+        assert mock_sleep.call_args_list == [call(_RETRY_DELAY_S)] * (_MAX_ATTEMPTS - 1)
 
     async def test_raises_update_failed_after_max_retries(self, hass_mock):
         """Should raise UpdateFailed after all 3 attempts fail with transient errors."""
@@ -450,10 +450,14 @@ class TestCoordinatorRetry:
         )
 
         with (
-            patch("custom_components.meteoam.coordinator.asyncio.sleep"),
+            patch("custom_components.meteoam.coordinator.asyncio.sleep") as mock_sleep,
             pytest.raises(UpdateFailed),
         ):
             await coordinator._async_update_data()
+
+        assert coordinator.weather.fetch_data.call_count == _MAX_ATTEMPTS
+        assert mock_sleep.call_count == _MAX_ATTEMPTS - 1
+        assert mock_sleep.call_args_list == [call(_RETRY_DELAY_S)] * (_MAX_ATTEMPTS - 1)
 
     async def test_no_retry_on_non_retryable_error(self, hass_mock):
         """Should raise UpdateFailed immediately on non-retryable CannotConnectError."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -74,6 +74,17 @@ def _mock_response(status: int = 200, json_data: dict | None = None) -> AsyncMoc
     return resp
 
 
+def _mock_session_get(resp: AsyncMock | None = None, *, error: Exception | None = None):
+    """Mock session.get as an async context manager."""
+    cm = MagicMock()
+    if error is not None:
+        cm.__aenter__ = AsyncMock(side_effect=error)
+    else:
+        cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=cm)
+
+
 # --- Tests ---
 
 
@@ -92,8 +103,8 @@ class TestFetchDataNetworkErrors:
     async def test_aiohttp_client_error_raises_cannot_connect(self, hass_mock):
         """aiohttp.ClientError should be caught and re-raised as CannotConnectError."""
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(
-            side_effect=aiohttp.ClientConnectionError("connection refused")
+        wd._session.get = _mock_session_get(
+            error=aiohttp.ClientConnectionError("connection refused")
         )
 
         with pytest.raises(CannotConnectError, match="Error connecting"):
@@ -102,7 +113,7 @@ class TestFetchDataNetworkErrors:
     async def test_timeout_error_raises_cannot_connect(self, hass_mock):
         """TimeoutError should be caught and re-raised as CannotConnectError."""
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(side_effect=TimeoutError("timed out"))
+        wd._session.get = _mock_session_get(error=TimeoutError("timed out"))
 
         with pytest.raises(CannotConnectError, match="Error connecting"):
             await wd.fetch_data()
@@ -110,7 +121,7 @@ class TestFetchDataNetworkErrors:
     async def test_non_200_status_raises_cannot_connect(self, hass_mock):
         """Non-200 HTTP status should raise CannotConnectError."""
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(return_value=_mock_response(status=503))
+        wd._session.get = _mock_session_get(_mock_response(status=503))
 
         with pytest.raises(CannotConnectError, match="API returned status 503"):
             await wd.fetch_data()
@@ -124,7 +135,7 @@ class TestFetchDataNetworkErrors:
                 MagicMock(), MagicMock(), message="not json"
             )
         )
-        wd._session.get = AsyncMock(return_value=resp)
+        wd._session.get = _mock_session_get(resp)
 
         with pytest.raises(CannotConnectError, match="Error parsing"):
             await wd.fetch_data()
@@ -134,7 +145,7 @@ class TestFetchDataNetworkErrors:
         wd = _make_weather_data(hass_mock)
         resp = _mock_response(status=200)
         resp.json = AsyncMock(side_effect=ValueError("bad json"))
-        wd._session.get = AsyncMock(return_value=resp)
+        wd._session.get = _mock_session_get(resp)
 
         with pytest.raises(CannotConnectError, match="Error parsing"):
             await wd.fetch_data()
@@ -142,9 +153,7 @@ class TestFetchDataNetworkErrors:
     async def test_empty_response_raises_cannot_connect(self, hass_mock):
         """Empty API response should raise CannotConnectError."""
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(
-            return_value=_mock_response(status=200, json_data={})
-        )
+        wd._session.get = _mock_session_get(_mock_response(status=200, json_data={}))
 
         with pytest.raises(CannotConnectError, match="empty response"):
             await wd.fetch_data()
@@ -157,8 +166,8 @@ class TestFetchDataParsingErrors:
         """Missing 'extrainfo' key should raise CannotConnectError."""
         wd = _make_weather_data(hass_mock)
         bad_data = {"timeseries": [], "paramlist": [], "datasets": {"0": {}}}
-        wd._session.get = AsyncMock(
-            return_value=_mock_response(status=200, json_data=bad_data)
+        wd._session.get = _mock_session_get(
+            _mock_response(status=200, json_data=bad_data)
         )
 
         with pytest.raises(CannotConnectError, match="Error processing"):
@@ -172,8 +181,8 @@ class TestFetchDataParsingErrors:
             "paramlist": ["2t"],
             "extrainfo": {"stats": []},
         }
-        wd._session.get = AsyncMock(
-            return_value=_mock_response(status=200, json_data=bad_data)
+        wd._session.get = _mock_session_get(
+            _mock_response(status=200, json_data=bad_data)
         )
 
         with pytest.raises(CannotConnectError, match="Error processing"):
@@ -191,9 +200,7 @@ class TestCurrentWeatherFallback:
 
         data = _build_api_response(timeseries=[past, future])
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(
-            return_value=_mock_response(status=200, json_data=data)
-        )
+        wd._session.get = _mock_session_get(_mock_response(status=200, json_data=data))
 
         await wd.fetch_data()
 
@@ -208,9 +215,7 @@ class TestCurrentWeatherFallback:
 
         data = _build_api_response(timeseries=[future1, future2])
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(
-            return_value=_mock_response(status=200, json_data=data)
-        )
+        wd._session.get = _mock_session_get(_mock_response(status=200, json_data=data))
 
         await wd.fetch_data()
 
@@ -228,9 +233,7 @@ class TestCurrentWeatherFallback:
         # First fetch: has a past entry → current weather populated
         data1 = _build_api_response(timeseries=[past, future])
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(
-            return_value=_mock_response(status=200, json_data=data1)
-        )
+        wd._session.get = _mock_session_get(_mock_response(status=200, json_data=data1))
         await wd.fetch_data()
         first_current = wd.current_weather_data.copy()
         assert first_current
@@ -239,9 +242,7 @@ class TestCurrentWeatherFallback:
         future1 = (now + timedelta(hours=1)).isoformat()
         future2 = (now + timedelta(hours=2)).isoformat()
         data2 = _build_api_response(timeseries=[future1, future2])
-        wd._session.get = AsyncMock(
-            return_value=_mock_response(status=200, json_data=data2)
-        )
+        wd._session.get = _mock_session_get(_mock_response(status=200, json_data=data2))
         await wd.fetch_data()
 
         # Should be the fallback (first hourly entry), not the stale past data
@@ -256,9 +257,7 @@ class TestCurrentWeatherFallback:
 
         data = _build_api_response(timeseries=[past, future1, future2])
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(
-            return_value=_mock_response(status=200, json_data=data)
-        )
+        wd._session.get = _mock_session_get(_mock_response(status=200, json_data=data))
 
         await wd.fetch_data()
 
@@ -357,9 +356,7 @@ class TestDailyForecastDatetime:
         ts = now.isoformat()
         data = _build_api_response(timeseries=[ts])
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(
-            return_value=_mock_response(status=200, json_data=data)
-        )
+        wd._session.get = _mock_session_get(_mock_response(status=200, json_data=data))
 
         await wd.fetch_data()
 
@@ -376,7 +373,7 @@ class TestTransientAPIError:
     async def test_5xx_raises_transient_error(self, hass_mock):
         """HTTP 5xx should raise TransientAPIError, a subclass of CannotConnectError."""
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(return_value=_mock_response(status=503))
+        wd._session.get = _mock_session_get(_mock_response(status=503))
 
         with pytest.raises(TransientAPIError, match="API returned status 503"):
             await wd.fetch_data()
@@ -384,8 +381,8 @@ class TestTransientAPIError:
     async def test_network_error_raises_transient_error(self, hass_mock):
         """aiohttp.ClientError should raise TransientAPIError."""
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(
-            side_effect=aiohttp.ClientConnectionError("connection refused")
+        wd._session.get = _mock_session_get(
+            error=aiohttp.ClientConnectionError("connection refused")
         )
 
         with pytest.raises(TransientAPIError, match="Error connecting"):
@@ -394,7 +391,7 @@ class TestTransientAPIError:
     async def test_4xx_raises_cannot_connect_not_transient(self, hass_mock):
         """HTTP 4xx should raise CannotConnectError but NOT TransientAPIError."""
         wd = _make_weather_data(hass_mock)
-        wd._session.get = AsyncMock(return_value=_mock_response(status=404))
+        wd._session.get = _mock_session_get(_mock_response(status=404))
 
         with pytest.raises(CannotConnectError) as exc_info:
             await wd.fetch_data()


### PR DESCRIPTION
This pull request adds robust error handling and retry logic to the MeteoAM integration, improving reliability when fetching weather data from the external API. The main enhancements are the introduction of a new `TransientAPIError` exception to distinguish retryable errors, implementing retries for transient failures, and comprehensive tests to verify this behavior.

**Error handling and retry logic improvements:**

- Introduced a new `TransientAPIError` exception, subclassing `CannotConnectError`, to represent network and HTTP 5xx errors that are safe to retry. (`custom_components/meteoam/coordinator.py`)
- Updated the `fetch_data` method to raise `TransientAPIError` for network issues and HTTP 5xx responses, while non-retryable errors (such as HTTP 4xx) continue to raise `CannotConnectError`. (`custom_components/meteoam/coordinator.py`)
- Modified the `_async_update_data` method in `MeteoAMDataUpdateCoordinator` to retry up to three times with a delay for `TransientAPIError`, logging each attempt and only failing after the maximum attempts. (`custom_components/meteoam/coordinator.py`) [[1]](diffhunk://#diff-6fdaa5806a5e3fdc42bd69158521a42fd44cbb594ac779826bd107f33a175662R27-R29) [[2]](diffhunk://#diff-6fdaa5806a5e3fdc42bd69158521a42fd44cbb594ac779826bd107f33a175662L60-R88)

**Testing:**

- Added new test cases to verify that transient errors are retried and non-retryable errors are not, including tests for network errors, HTTP 5xx/4xx responses, and the retry mechanism itself. (`tests/test_coordinator.py`)
- Updated imports in the test file to include the new exception and coordinator class. (`tests/test_coordinator.py`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry mechanism for temporary API connectivity issues and server-side errors to improve data reliability.
* **Bug Fixes**
  * Better classification of transient vs permanent failures so recoverable errors trigger retries while permanent errors fail fast.
* **Tests**
  * Added tests validating retry behavior, sleep/delay handling, and correct error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->