### PR TITLE
feat: add precipitation probability to daily forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Home Assistant custom component that provides weather data from the Italian Ai
 ## Features
 
 - **Current weather conditions**: temperature, humidity, pressure, wind speed & bearing, precipitation probability
-- **Daily forecast** with high/low temperatures and condition icons
+- **Daily forecast** with high/low temperatures, condition icons, and precipitation probability
 - **Hourly forecast** with full weather details including precipitation probability
 - **Track home location**: automatically updates when your Home Assistant home location changes
 - **Multiple locations**: configure as many weather entities as you need
@@ -75,7 +75,7 @@ You can reconfigure latitude and longitude later via the integration's **Options
 Weather forecast data is fetched from the MeteoAM API (`api.meteoam.it`), which provides ECMWF-based model output:
 
 - **Hourly forecast**: up to ~4 days ahead (hourly for 3 days, then 3-hourly)
-- **Daily forecast**: up to 5 days ahead with min/max temperatures
+- **Daily forecast**: up to 5 days ahead with min/max temperatures and precipitation probability (derived as the max hourly value per day, since the API only provides it hourly)
 - **Update interval**: approximately every 60 minutes (randomized 55–65 min)
 
 ## Development

--- a/custom_components/meteoam/coordinator.py
+++ b/custom_components/meteoam/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable, Mapping
-from datetime import timedelta
+from datetime import date, timedelta
 from random import randrange
 from typing import Any, Self
 
@@ -193,20 +193,6 @@ class MeteoAMWeatherData:
 
     def _parse_data(self, data: dict[str, Any]) -> None:
         """Parse the API response data."""
-        # Parse daily forecast from stats
-        self.daily_forecast = []
-        for item in data["extrainfo"]["stats"]:
-            parsed_dt = dt_util.parse_datetime(item["localDate"])
-            if parsed_dt is None:
-                continue
-            element = {
-                "localDateTime": parsed_dt.isoformat(),
-                "2t": item["maxCelsius"],
-                "2t_min": item["minCelsius"],
-                "icon": item["icon"],
-            }
-            self.daily_forecast.append(element)
-
         # Parse hourly forecast from timeseries
         hourly_forecast: list[dict] = []
         timeseries_data = data["timeseries"]
@@ -215,6 +201,11 @@ class MeteoAMWeatherData:
         now = dt_util.now()
 
         current_weather_data: dict[str, Any] = {}
+
+        # The API exposes precipitation probability ("tpp") only per hour, not in
+        # the daily stats. Track the max hourly probability per local date so it
+        # can be attached to the daily forecast below.
+        daily_precip_probability: dict[date, float] = {}
 
         for tidx, t in enumerate(timeseries_data):
             parsed_dt = dt_util.parse_datetime(t)
@@ -227,6 +218,13 @@ class MeteoAMWeatherData:
             for pidx, p in enumerate(paramlist_data):
                 element[p] = datasets[str(pidx)][tidx_str]
 
+            tpp = element.get("tpp")
+            if tpp is not None:
+                day = local_dt.date()
+                daily_precip_probability[day] = max(
+                    daily_precip_probability.get(day, tpp), tpp
+                )
+
             if local_dt <= now:
                 current_weather_data = element
             if local_dt >= now:
@@ -238,3 +236,21 @@ class MeteoAMWeatherData:
 
         self.current_weather_data = current_weather_data
         self.hourly_forecast = hourly_forecast
+
+        # Parse daily forecast from stats, enriching it with the per-day max
+        # precipitation probability derived from the hourly data.
+        self.daily_forecast = []
+        for item in data["extrainfo"]["stats"]:
+            parsed_dt = dt_util.parse_datetime(item["localDate"])
+            if parsed_dt is None:
+                continue
+            element = {
+                "localDateTime": parsed_dt.isoformat(),
+                "2t": item["maxCelsius"],
+                "2t_min": item["minCelsius"],
+                "icon": item["icon"],
+            }
+            tpp = daily_precip_probability.get(dt_util.as_local(parsed_dt).date())
+            if tpp is not None:
+                element["tpp"] = tpp
+            self.daily_forecast.append(element)

--- a/custom_components/meteoam/coordinator.py
+++ b/custom_components/meteoam/coordinator.py
@@ -35,6 +35,14 @@ _LOGGER = logging.getLogger(__name__)
 type MeteoAMConfigEntry = ConfigEntry[MeteoAMDataUpdateCoordinator]
 
 
+def _to_float_or_none(value: Any) -> float | None:
+    """Coerce an API value to float, returning None for missing placeholders."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 class CannotConnectError(HomeAssistantError):
     """Unable to connect to the web site."""
 
@@ -244,10 +252,15 @@ class MeteoAMWeatherData:
             parsed_dt = dt_util.parse_datetime(item["localDate"])
             if parsed_dt is None:
                 continue
+            # The API pads the last day(s) of the range with "-" placeholders
+            # when no model data is available. Skip those incomplete days.
+            max_temp = _to_float_or_none(item["maxCelsius"])
+            if max_temp is None:
+                continue
             element = {
                 "localDateTime": parsed_dt.isoformat(),
-                "2t": item["maxCelsius"],
-                "2t_min": item["minCelsius"],
+                "2t": max_temp,
+                "2t_min": _to_float_or_none(item["minCelsius"]),
                 "icon": item["icon"],
             }
             tpp = daily_precip_probability.get(dt_util.as_local(parsed_dt).date())

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -324,6 +324,33 @@ class TestCurrentWeatherFallback:
 
         assert "tpp" not in wd.daily_forecast[0]
 
+    async def test_daily_forecast_skips_placeholder_days(self, hass_mock):
+        """Days the API pads with '-' placeholders should be dropped."""
+        now = dt_util.now()
+        t0 = now.replace(hour=10, minute=0, second=0, microsecond=0)
+        stats = [
+            {
+                "localDate": t0.isoformat(),
+                "maxCelsius": 20,
+                "minCelsius": 10,
+                "icon": "01",
+            },
+            {
+                "localDate": (t0 + timedelta(days=1)).isoformat(),
+                "maxCelsius": "-",
+                "minCelsius": "-",
+                "icon": "-",
+            },
+        ]
+        data = _build_api_response(timeseries=[t0.isoformat()], stats=stats)
+        wd = _make_weather_data(hass_mock)
+        wd._session.get = _mock_session_get(_mock_response(status=200, json_data=data))
+
+        await wd.fetch_data()
+
+        assert len(wd.daily_forecast) == 1
+        assert wd.daily_forecast[0]["2t"] == 20.0
+
 
 class TestFetchDataPreconditions:
     """Tests for fetch_data precondition checks."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -264,6 +264,66 @@ class TestCurrentWeatherFallback:
         assert len(wd.hourly_forecast) == 2
         assert len(wd.daily_forecast) == 1
 
+    async def test_daily_forecast_includes_max_precip_probability(self, hass_mock):
+        """Daily forecast should carry the max hourly tpp for that day."""
+        now = dt_util.now()
+        t0 = now.replace(hour=10, minute=0, second=0, microsecond=0)
+        t1 = t0 + timedelta(hours=1)
+        paramlist = ["tpp", "icon"]
+        datasets = {
+            "0": {
+                "0": {"0": 20, "1": 80},  # tpp
+                "1": {"0": "01", "1": "01"},  # icon
+            }
+        }
+        stats = [
+            {
+                "localDate": t0.isoformat(),
+                "maxCelsius": 20,
+                "minCelsius": 10,
+                "icon": "01",
+            }
+        ]
+        data = _build_api_response(
+            timeseries=[t0.isoformat(), t1.isoformat()],
+            paramlist=paramlist,
+            datasets=datasets,
+            stats=stats,
+        )
+        wd = _make_weather_data(hass_mock)
+        wd._session.get = _mock_session_get(_mock_response(status=200, json_data=data))
+
+        await wd.fetch_data()
+
+        assert wd.daily_forecast[0]["tpp"] == 80
+
+    async def test_daily_forecast_omits_precip_when_no_tpp(self, hass_mock):
+        """Daily forecast should not carry tpp when the API omits it."""
+        now = dt_util.now()
+        t0 = now.replace(hour=10, minute=0, second=0, microsecond=0)
+        paramlist = ["2t", "icon"]
+        datasets = {"0": {"0": {"0": 15}, "1": {"0": "01"}}}
+        stats = [
+            {
+                "localDate": t0.isoformat(),
+                "maxCelsius": 20,
+                "minCelsius": 10,
+                "icon": "01",
+            }
+        ]
+        data = _build_api_response(
+            timeseries=[t0.isoformat()],
+            paramlist=paramlist,
+            datasets=datasets,
+            stats=stats,
+        )
+        wd = _make_weather_data(hass_mock)
+        wd._session.get = _mock_session_get(_mock_response(status=200, json_data=data))
+
+        await wd.fetch_data()
+
+        assert "tpp" not in wd.daily_forecast[0]
+
 
 class TestFetchDataPreconditions:
     """Tests for fetch_data precondition checks."""


### PR DESCRIPTION
## Summary

The MeteoAM API provides precipitation probability (`tpp`) **only per hour**, not in the daily stats block. The hourly forecast already exposed it, but the daily forecast did not. This adds it to the daily forecast and fixes a related malformed-entry bug.

## Changes

- **Daily precipitation probability**: derived from the hourly `tpp` values as the **max per local day** (the HA-core/met.no convention), then attached to each daily forecast entry. `FORECAST_MAP` already routed `tpp → ATTR_FORECAST_PRECIPITATION_PROBABILITY`, so no `weather.py` change was needed.
- **Placeholder-day fix**: the API pads the trailing day(s) of the daily range with `"-"` when no model data is available, which previously produced malformed forecast entries (non-numeric `native_temperature`). Temperatures are now coerced to `float` and days without a valid max temperature are skipped.
- **README**: documents the new daily attribute and how it's derived.

## Testing

- 40 unit tests pass (3 new: max-per-day aggregation, omission when `tpp` absent, placeholder-day skipping); `ruff` clean.
- Verified end-to-end on **live API data** through the real HA entity stack: 6 raw daily stats → 5 valid `Forecast` dicts (placeholder day dropped), each carrying `precipitation_probability` (0/35/0/55/75%) with float temps.
- Confirmed the integration sets up and fetches successfully in a real Home Assistant runtime with no errors.

Closes #32.